### PR TITLE
Include error handling to modular inverse

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -123,7 +123,10 @@ def GCD(x,y):
     return y
 
 def inverse(u, v):
-    """The inverse of :data:`u` *mod* :data:`v`."""
+    """The inverse of :data:`u` *mod* :data:`v`.
+    
+    The base `u` and modulus `v` must be coprime
+    """
 
     u3, v3 = u, v
     u1, v1 = 1, 0
@@ -131,7 +134,9 @@ def inverse(u, v):
         q = u3 // v3
         u1, v1 = v1, u1 - v1*q
         u3, v3 = v3, u3 - v3*q
-    while u1<0:
+    if u3 > 1:
+        raise ValueError("base is not invertible for the given modulus")
+    while u1 < 0:
         u1 = u1 + v
     return u1
 


### PR DESCRIPTION
### Description of problem

Currently, the function `inverse(u,v)` has no error handling for when the base and modulus are not coprime. This leads to unexpected results for bad input. This can be particularly bad for cryptographic verification which relies on the computation of the modular inverse of user input.

For example, using the current code, we can use `inverse(u,v)` to attempt to find the modular inverse even when the base `u = 0` or when the base and modulus are not coprime `gcd(u,v) != 1`:

```python
>>> x = 0; y = inverse(x,11); assert (x*y) % 11 == 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> x = 2; y = inverse(x,22); assert (x*y) % 11 == 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```

### Proposed fix

This pull request introduces an additional check after performing the extended Euclidian algorithm to ensure that the output value indeed is the modular inverse. This follows the following Wikipedia [pseudocode](https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm#Modular_integers).

Effectively, this check is the same as ensuring that the base `u` and the modulus `v` are coprime `gcd(u,v) = 1` and raises a `ValueError` when this is not the case. In terms of performance, one additional integer comparison is included into the function.

```py
def inverse(u, v):
    """The inverse of :data:`u` *mod* :data:`v`."""
    u3, v3 = u, v
    u1, v1 = 1, 0
    while v3 > 0:
        q = u3 // v3
        u1, v1 = v1, u1 - v1*q
        u3, v3 = v3, u3 - v3*q
    if u3>1:
        raise ValueError("base is not invertible for the given modulus")
    while u1<0:
        u1 = u1 + v
    return u1
```

With the proposed change, running the same examples as above, we see bad inputs are caught and raised as a `ValueError` before returning an incorrect "inverse" element. 

```py
>>> x = 0; y = inverse(x,11); assert (x*y) % 11 == 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 10, in inverse
ValueError: base is not invertible for the given modulus
>>> x = 2; y = inverse(x,22); assert (x*y) % 11 == 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 10, in inverse
ValueError: base is not invertible for the given modulus
```

### Alignment with proposed performance enhancement

In the pull request [Improve speed of GCD, size, inverse](https://github.com/Legrandin/pycryptodome/pull/484), it is proposed that for newer versions of python (from 3.8) that inverse uses the faster, native inverse.

```py
if sys.version_info[:2] >= (3,8):
    def inverse(u,v):
        return pow(u,-1,v)
else:
    ...
```

This pull request will align the error handling of `pycryptodome`s inverse with python's `pow(u,-1,v)`:

```py
>>> pow(0,-1,11)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: base is not invertible for the given modulus
>>> pow(2,-1,22)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: base is not invertible for the given modulus
```

Allowing `inverse(u,v)` to be consistent across python versions.
